### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/templates/msaviz/msa.html
+++ b/templates/msaviz/msa.html
@@ -54,7 +54,7 @@
     <article id="publications" class="list">
         <ul id="pub-container" class="pubs">
             <li>
-                <a target="_blank" href="http://dx.doi.org/10.1093/bioinformatics/btw474">
+                <a target="_blank" href="https://doi.org/10.1093/bioinformatics/btw474">
                     <div class="pub-date">
                         2016
                     </div>

--- a/tools/models.py
+++ b/tools/models.py
@@ -357,7 +357,7 @@ class Citation(models.Model):
             year = v.get('year','')
             authors = v.get('author','')
             doi = v.get('doi','')
-            f.append(authors + "("+year+"). "+title+" . "+journal+" <a href=\"https://dx.doi.org/"+doi+"\">doi</a>\n")
+            f.append(authors + "("+year+"). "+title+" . "+journal+" <a href=\"https://doi.org/"+doi+"\">doi</a>\n")
         return f
 
 class ToolFlag(models.Model):


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Although there is no urgent need to do anything, I'd hereby like to suggest to follow the new recommendation and update the one static DOI link and the code that generates new DOIs links.

Cheers!